### PR TITLE
Oops!  All lines containing "Begin"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 Change log
 ==========
 
-Version 0.3.1 - 8 Apr 2013
+Version 0.3.2 - 8 Apr 2013
 ------------------------
 
 matonb:
-* Patched - Serious Problem:  SanitizeTextFiles If logic removed all lines containing "Begin".
+* 0.3.1 Patched - Serious Problem:  SanitizeTextFiles If logic removed all lines containing "Begin".
+* 0.3.2 Replaced if block for skipping code sections in SanitizeTextFiles with regular expression.
 
 Version 0.3 - 6 Apr 2013
 ------------------------


### PR DESCRIPTION
If logic problem in sanitize files removing all lines containing "Begin".
  Not really fixed per-se, but patched to work around.
